### PR TITLE
Make source_code truly optional

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -13,6 +13,7 @@ __all__ = [
     "ParentAsset",
     "LeafAsset",
     "Lineage",
+    "LineageWithSource",
     "CustomLineageConfig",
 ]
 
@@ -70,13 +71,16 @@ class LeafAsset(BaseModel):
 class Lineage(BaseModel):
     src: Union[LeafAsset, ParentAsset]
     trg: Union[LeafAsset, ParentAsset]
-    source_code: Optional[SourceCode] = None
 
     @model_validator(mode="after")
     def verify_allowed_relationship(self) -> "Lineage":
         if isinstance(self.src, ParentAsset) and isinstance(self.trg, LeafAsset):
             raise ValueError("If src is a ParentAsset, trg has to be a ParentAsset as well (table level lineage).")
         return self
+
+
+class LineageWithSource(Lineage):
+    source_code: SourceCode
 
 
 class CustomLineageConfig:

--- a/tests/test_data/conversion/lineage.json
+++ b/tests/test_data/conversion/lineage.json
@@ -105,8 +105,27 @@
             "column": "col2"
           }
         ],
-        "mapping": "VIEW1 creation",
-        "source_code": "SELECT col1, col2 from T1;"
-      }]
+        "mapping_ref": {
+            "mapping": "VIEW1_creation",
+            "source_code": "transforms.sql",
+            "codebase_pos": [
+              {
+                "pos_start": 0,
+                "pos_len": 26
+              }
+            ]
+          }
+        }
+],
+"codebase_files": {
+  "transforms.sql": {
+    "mapping_refs": {
+      "VIEW1_creation": {
+        "pos_start": 0,
+        "pos_len": 26
+      }
+    }
+  }
+}
   }
   

--- a/tests/test_data/conversion/lineage_v3_no_source_code.json
+++ b/tests/test_data/conversion/lineage_v3_no_source_code.json
@@ -49,11 +49,6 @@
         "type": "Column"
       },
       "props": null
-    },
-    "source_code": {
-      "path": "source_codes/uuid.txt",
-      "highlights": null,
-      "transformation_display_name": "VIEW1 creation"
     }
   },
   {
@@ -106,16 +101,6 @@
         "type": "Column"
       },
       "props": null
-    },
-    "source_code": {
-      "path": "source_codes/uuid.txt",
-      "highlights": [
-        {
-          "start": 0,
-          "len": 26
-        }
-      ],
-      "transformation_display_name": "VIEW1_creation"
     }
   }
 ]

--- a/tests/test_data/conversion/transforms.sql
+++ b/tests/test_data/conversion/transforms.sql
@@ -1,0 +1,1 @@
+SELECT col1, col2 from T1;

--- a/tests/test_data/csv/lineage_v3.json
+++ b/tests/test_data/csv/lineage_v3.json
@@ -183,7 +183,6 @@
               "type": "Column"
           },
           "props": null
-      },
-      "source_code": null
+      }
   }
 ]

--- a/tests/test_translate_to_batch_format.py
+++ b/tests/test_translate_to_batch_format.py
@@ -3,6 +3,7 @@ import shutil
 
 from tools.translate_to_batch_format import convert
 
+
 def test_translate_with_simple_and_advanced_source_code() -> None:
     convert(
         input_directory="./test_data/conversion",
@@ -32,6 +33,7 @@ def test_translate_with_simple_and_advanced_source_code() -> None:
 
     # cleanup
     shutil.rmtree("./test_data/conversion/v3", ignore_errors=True)
+
 
 def test_translat_without_source_code() -> None:
     # convert input

--- a/tests/test_translate_to_batch_format.py
+++ b/tests/test_translate_to_batch_format.py
@@ -3,6 +3,35 @@ import shutil
 
 from tools.translate_to_batch_format import convert
 
+def test_translate_with_simple_and_advanced_source_code() -> None:
+    convert(
+        input_directory="./test_data/conversion",
+        output_directory="./test_data/conversion/v3",
+        migrate_source_code=True,
+    )
+
+    # compare converted with expected
+    with open("./test_data/conversion/metadata.json") as input_file:
+        expected_metadata = json.load(input_file)
+
+    with open("./test_data/conversion/v3/metadata.json") as input_file:
+        generated_metadata = json.load(input_file)
+
+    with open("./test_data/conversion/lineage_v3.json") as input_file:
+        expected_lineage = json.load(input_file)
+
+    with open("./test_data/conversion/v3/lineage.json") as input_file:
+        generated_lineage = json.load(input_file)
+
+    for lineage in generated_lineage:
+        if lineage.get("source_code"):
+            lineage["source_code"]["path"] = "source_codes/uuid.txt"
+
+    assert expected_metadata == generated_metadata
+    assert expected_lineage == generated_lineage
+
+    # cleanup
+    shutil.rmtree("./test_data/conversion/v3", ignore_errors=True)
 
 def test_translat_without_source_code() -> None:
     # convert input
@@ -19,7 +48,7 @@ def test_translat_without_source_code() -> None:
     with open("./test_data/conversion/v3/metadata.json") as input_file:
         generated_metadata = json.load(input_file)
 
-    with open("./test_data/conversion/lineage_v3.json") as input_file:
+    with open("./test_data/conversion/lineage_v3_no_source_code.json") as input_file:
         expected_lineage = json.load(input_file)
 
     with open("./test_data/conversion/v3/lineage.json") as input_file:

--- a/tools/ingest_csv.py
+++ b/tools/ingest_csv.py
@@ -12,6 +12,7 @@ from src.models import (
     CustomLineageConfig,
     LeafAsset,
     Lineage,
+    LineageWithSource,
     NodeAsset,
     ParentAsset,
     SourceCode,
@@ -205,7 +206,10 @@ def ingest_csv_files(source_directory: str, custom_lineage_config: CustomLineage
                     line=line,
                 )
 
-                lineages.append(Lineage(src=src, trg=trg, source_code=source_code))
+                if not source_code:
+                    lineages.append(Lineage(src=src, trg=trg))
+                else:
+                    lineages.append(LineageWithSource(src=src, trg=trg, source_code=source_code))
 
     if custom_lineage_config.dic_info_provided:
         # collect uuid from DIC

--- a/tools/translate_to_batch_format.py
+++ b/tools/translate_to_batch_format.py
@@ -142,7 +142,7 @@ def convert_lineages(
             lineage_relationship = LineageWithSource(
                 src=_convert_lineage_node(lineage_relationship_v1["src_path"]),
                 trg=_convert_lineage_node(lineage_relationship_v1["trg_path"]),
-                source_code=source_code
+                source_code=source_code,
             )
         else:
             lineage_relationship = Lineage(


### PR DESCRIPTION
### Description of your changes

Differentiate between Lineage and LineageWithSource in ingest_csv.py to allow lineage both with and without source code.

Currently, if an ingested csv file has a row with no source code, or a custom lineage v1 file is converted with `migrate_source_code=False`, it will create an object in `lineage.json` like

```
  [
     {
        "src": {},
        "trg": {},
        "source_code": null
     }
  ]
```

The `source_code` property being null results in this error

```
harvester.error.ShowcaseClientError: To resolve the error, please visit our Troubleshooting documentation: https://support.collibra.com/hc/en-us/articles/13453781015063. Showcase returning client error: 
com.github.fge.jsonschema.core.report.ListProcessingReport: failure
--- BEGIN MESSAGES ---
info: ERRORS FOR SCHEMA lineage
    level: \"info\"
warning: the following keywords are unknown and will be ignored: [$defs]
    level: \"warning\"
    schema: {\"loadingURI\":\"#\",\"pointer\":\"\"}
    domain: \"syntax\"
    ignored: [\"$defs\"]
error: instance type (null) does not match any allowed primitive type (allowed: [\"object\"])
    level: \"error\"
    schema: {\"loadingURI\":\"#\",\"pointer\":\"/properties/source_code\"}
    instance: {\"pointer\":\"/source_code\"}
    domain: \"validation\"
    keyword: \"type\"
    found: \"null\"
    expected: [\"object\"]
---  END MESSAGES  ---
```

Due to the [lineage schema](https://github.com/collibra/lin-sqldep/blob/main/custom-lineage-scanner/src/main/resources/schema/lineage_schema.json) requiring the `source_code` property to be of `"type": "object."` The lineage schema could be modified to allow `"type": ["object", "null"]` but because `lineage.json` files are only required to have `src` and `trg` properties, I believe changing the helper scripts to completely omit `source_code` if it's empty is less impactful overall.

---

### JIRA reference

None

---

### Impact Analysis

This change handles a particular case that was not being handled before so overall hopefully makes the code more resilient. Existing functionality should not be impacted.

---

#### Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the contribution guidelines of this project
- [x] My changes generate no new warnings
