### PR TITLE
Update helper.py to handle long value in source_code column

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ System,Database,Schema,Table,Column,fullname,domain_id,System,Database,Schema,Ta
  * A value for the leaf asset type is optional.
  * Values for `fullname` and `domain_id` are optional.
  * Values for `source_code`, `highlights`, and `transformation_display_name` are optional.
- * `source_code` can either be a string or the full path to a file.
+ * `source_code` can either be a string or the full path to a file. **Note:** the detection of whether the value is a file path or inline text is done automatically. If the value exceeds 255 characters in any single path component, it will always be treated as inline text, regardless of whether it looks like a file path. Therefore, file paths with individual components exceeding 255 characters are not supported.
 
 Headers define the asset types for which you define the lineage relationships; therefore, one file can only contain lineage relationships for the same type of assets in the source/target. You can, however, create as many CSV files as you want in the directory. The generated `metadata.json` file will contain the definition for `System`, `Database`, `Schema`, `Table`, and `Column`. If you are using any other asset types, you need to add these in the `metadata.json` file, with their respective `uuid`.
  

--- a/src/helper.py
+++ b/src/helper.py
@@ -91,8 +91,16 @@ def generate_source_code(
     :returns: SourceCode object constructed using the provided input
     :rtype: SourceCode
     """
-    # in case of a file
-    if Path(source_code_text).is_file():
+    # in case of a file — guard against OSError when source_code_text is a long
+    # string (e.g. inline SQL) that exceeds the OS filename length limit (255 chars
+    # on Linux). Path.is_file() calls os.stat() internally, which raises
+    # OSError: [Errno 36] File name too long in that situation.
+    try:
+        is_file = Path(source_code_text).is_file()
+    except OSError:
+        is_file = False
+
+    if is_file:
         file_name = Path(source_code_text).name
         shutil.copy(source_code_text, custom_lineage_config.source_code_directory_path / file_name)
     else:


### PR DESCRIPTION
Fix OSError for long source_code strings exceeding 255 chars.  Case when in csv file in a column "source_code" is provided a sql code that is more than 255 chars, and that should be presented in custom lineage.


### Description of your changes

When the source_code column in a CSV contains a long SQL string (over 255 characters), Path.is_file() in generate_source_code triggers an os.stat() call that exceeds the Linux filename length limit, causing OSError: [Errno 36] File name too long. Fixed by wrapping the check in a try/except OSError block.


### JIRA reference


---

#### Checklist

- [ ] I have performed a self-review of my code
- [ ] My code follows the contribution guidelines of this project
- [ ] My changes generate no new warnings
